### PR TITLE
add admin_movies_controller spec

### DIFF
--- a/app/controllers/admin/v1/movies_controller.rb
+++ b/app/controllers/admin/v1/movies_controller.rb
@@ -11,6 +11,9 @@ class Admin::V1::MoviesController < ApplicationController
   end
 
   def destroy
+    @movie = Movie.find(params[:id])
+    @movie.destroy!(movie_params)
+    render json: { status: 204, data: @movie }
   end
 
   private

--- a/app/controllers/admin/v1/movies_controller.rb
+++ b/app/controllers/admin/v1/movies_controller.rb
@@ -12,8 +12,8 @@ class Admin::V1::MoviesController < ApplicationController
 
   def destroy
     @movie = Movie.find(params[:id])
-    @movie.destroy!(movie_params)
-    render json: { status: 204, data: @movie }
+    @movie.destroy!
+    render json: { status: 204, data: {} }
   end
 
   private

--- a/spec/requests/admin/v1/movies_controller_spec.rb
+++ b/spec/requests/admin/v1/movies_controller_spec.rb
@@ -44,16 +44,16 @@ describe Admin::V1::MoviesController, type: :request do
     subject { post(admin_v1_movies_path, params: params) }
 
     context "destroy data" do
+      let!(:movie) { create(:movie) }
       let(:params) { { movie: { title: title } } }
       let(:title) { "test_title" }
 
       it do
         aggregate_failures do
+          binding.pry
           expect { subject }.to change { Movie.count }.by(-1)
           json = JSON.parse(response.body)
           expect(json["status"]).to eq 204
-          movie = Movie.last
-          expect(movie.title).to eq title
         end
       end
     end

--- a/spec/requests/admin/v1/movies_controller_spec.rb
+++ b/spec/requests/admin/v1/movies_controller_spec.rb
@@ -41,16 +41,13 @@ describe Admin::V1::MoviesController, type: :request do
   end
 
   describe "destroy" do
-    subject { post(admin_v1_movies_path, params: params) }
+    subject { delete(admin_v1_movie_path(movie.id)) }
 
-    context "destroy data" do
+    context "the data" do
       let!(:movie) { create(:movie) }
-      let(:params) { { movie: { title: title } } }
-      let(:title) { "test_title" }
 
       it do
         aggregate_failures do
-          binding.pry
           expect { subject }.to change { Movie.count }.by(-1)
           json = JSON.parse(response.body)
           expect(json["status"]).to eq 204

--- a/spec/requests/admin/v1/movies_controller_spec.rb
+++ b/spec/requests/admin/v1/movies_controller_spec.rb
@@ -39,4 +39,23 @@ describe Admin::V1::MoviesController, type: :request do
       end
     end
   end
+
+  describe "destroy" do
+    subject { post(admin_v1_movies_path, params: params) }
+
+    context "destroy data" do
+      let(:params) { { movie: { title: title } } }
+      let(:title) { "test_title" }
+
+      it do
+        aggregate_failures do
+          expect { subject }.to change { Movie.count }.by(-1)
+          json = JSON.parse(response.body)
+          expect(json["status"]).to eq 204
+          movie = Movie.last
+          expect(movie.title).to eq title
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 admin_movies_controllerの、destroyメソッドのテストを作成しました

## 質問
Rspecを実行すると、以下のようなエラーが出てしまいます。
`Failures:  1) Admin::V1::MoviesController destroy destroy data should eq "test_title"
     Failure/Error: expect { subject }.to change { Movie.count }.by(-1)
       expected `Movie.count` to have changed by -1, but was changed by 1`


`let!(:movie) { create(movie) }`のような処理をどこかに書かなければならないのでしょうか？